### PR TITLE
Fix colon windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ github-wiki-sidebar --git-push
 github-wiki-sidebar --silent --git-push
 ```
 
+>Obs: If you are on **Windows** environment, you can't name a file with collon, so search in `options.json` for the line `"separator": ":-",` and change it `"separator": "꞉-",`, and then execute the `fix-colon-windows.sh` that is in `scripts` directory.
+
 [![Generate custom GitHub wiki sidebar with order and custom template - asciicast](https://asciinema.org/a/vhcfzXYJclbJqRI2zU1exDQwh.png)](https://asciinema.org/a/vhcfzXYJclbJqRI2zU1exDQwh)
 
 

--- a/scripts/fix-colon-windows.sh
+++ b/scripts/fix-colon-windows.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# I was playing with "Github Wiki Sidebar" in a windows machine, and found out that something was missing
+# when I cloned it´s wiki repository: "https://github.com/adriantanasa/github-wiki-sidebar.wiki.git". The
+# problem was some "forbidden" file names that could not be checked out in windows.
+#
+# Some usefull links:
+# - [Github Wiki Sidebar](https://github.com/adriantanasa/github-wiki-sidebar)
+# - [Git clone leads to deleted & untracked files](https://stackoverflow.com/questions/38980293/git-clone-leads-to-deleted-untracked-files/38992095)
+# - [What characters are forbidden in Windows and Linux directory names](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names)
+# - [How to get a file in Windows with a colon in the filename](https://stackoverflow.com/questions/10386344/how-to-get-a-file-in-windows-with-a-colon-in-the-filename)
+# - [Checkout older revision of a file under a new name in Git](https://stackoverflow.com/questions/888414/git-checkout-older-revision-of-a-file-under-a-new-name)
+# - [FINDSTR in FOR loop with variables as strings](https://stackoverflow.com/questions/24415011/findstr-in-for-loop-with-variables-as-strings-batch-file)
+# - [Removing files with rm using find and xargs](https://stackoverflow.com/questions/42828021/removing-files-with-rm-using-find-and-xargs)
+# - [How to hide command output in Bash](https://stackoverflow.com/questions/18062778/how-to-hide-command-output-in-bash)
+# - [Fun With GIT and AWK](http://travistidwell.com/blog/2014/06/11/fun-with-git-and-awk/)
+# - [How to escape a single quote inside awk](https://stackoverflow.com/questions/9899001/how-to-escape-a-single-quote-inside-awk)
+# - [How do I paste multi-line bash codes into terminal and run it all at once](https://stackoverflow.com/questions/6713056/how-do-i-paste-multi-line-bash-codes-into-terminal-and-run-it-all-at-once/43164204)
+#
+git ls-files -o | xargs rm &> /dev/null; \
+git status --short | findstr -v ? | cut -b 4- | awk '{ 
+x=$0; gsub(":","꞉", $0); y=$0;
+system("git show HEAD^:'\''"x"'\''>'\''"y"'\''") 
+}' &> /dev/null; \
+git add -A &> /dev/null; \
+git commit -m "Renamed some file names with a colon that windows accepts" &> /dev/null; \
+echo done;


### PR DESCRIPTION
I cloned wiki project on a Windows machine and something strange happened:

![image](https://user-images.githubusercontent.com/9537294/90324760-21268280-df49-11ea-9d21-70e6b75360e3.png)

After a little bit of research I found out some kind of solution for the problem...

![image](https://user-images.githubusercontent.com/9537294/90324842-318b2d00-df4a-11ea-87aa-75742a356020.png)

And after that...

![image](https://user-images.githubusercontent.com/9537294/90324874-8f1f7980-df4a-11ea-9065-fe9705677c8a.png)

The results...

![image](https://user-images.githubusercontent.com/9537294/90324898-ec1b2f80-df4a-11ea-8afb-4e54728ce259.png)

